### PR TITLE
Updating Docker Image Version(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8 as builder
+FROM openjdk:8@sha256:3af2ac94130765b73fc8f1b42ffc04f77996ed8210c297fcfa28ca880ff0a217 as builder
 ADD . /code/
 RUN \
     cd /code/ && \
@@ -9,7 +9,7 @@ RUN \
     mv /code/target/*.war /jhipster-registry.war && \
     rm -Rf /code/ /root/.m2 /root/.cache /tmp/*
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre-alpine@sha256:b2ad93b079b1495488cc01375de799c402d45086015a120c105ea00e1be0fd52
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     SPRING_PROFILES_ACTIVE=prod,native \
     GIT_URI=https://github.com/jhipster/jhipster-registry/ \


### PR DESCRIPTION
1. Updating version for openjdk:8 to sha256:3af2ac94130765b73fc8f1b42ffc04f77996ed8210c297fcfa28ca880ff0a217
2. Updating version for openjdk:8-jre-alpine to sha256:b2ad93b079b1495488cc01375de799c402d45086015a120c105ea00e1be0fd52
